### PR TITLE
Edited getmdl-select library to use MutationObserver.

### DIFF
--- a/getmdl-select/getmdl-select.js
+++ b/getmdl-select/getmdl-select.js
@@ -3,9 +3,7 @@
     window.initializeMdlSelect = function () {
         new MutationObserver(function (ev) {
             ev.forEach(function (mu) {
-                mu.addedNodes.forEach(function(ad){
-                    componentHandler.upgradeDom();
-                });
+                componentHandler.upgradeDom();
             })
         }).observe(document, { childList: true, subtree: true });
     };

--- a/getmdl-select/getmdl-select.js
+++ b/getmdl-select/getmdl-select.js
@@ -1,12 +1,13 @@
 {
     'use strict';
     window.initializeMdlSelect = function () {
-        getmdlSelect.init('.getmdl-select');
-        document.addEventListener("DOMNodeInserted", function (ev) {
-            if (ev.relatedNode.querySelectorAll(".getmdl-select").length > 0) {
-                componentHandler.upgradeDom();
-            }
-        }, false);
+        new MutationObserver(function (ev) {
+            ev.forEach(function (mu) {
+                mu.addedNodes.forEach(function(ad){
+                    componentHandler.upgradeDom();
+                });
+            })
+        }).observe(document, { childList: true, subtree: true });
     };
 
     var getmdlSelect = {

--- a/js/getForm.js
+++ b/js/getForm.js
@@ -1,5 +1,6 @@
 $(document).ready(function(){
 	var error = 0;
+	initializeMdlSelect();
 	$.when($.ajax({
 		url:"../php/getType.php",
 		datatype:"json",
@@ -39,7 +40,7 @@ $(document).ready(function(){
 		if(error == 0){
 			$('#formSpinner').hide();
 		 	$('#application').removeClass('hidden');
-			initializeMdlSelect();
+	        getmdlSelect.init('.getmdl-select');
 		}
 		else{
 			$('#formSpinner').hide();


### PR DESCRIPTION
The getmdl-select library used event listeners, which generated warning messages in browsers like Firefox, and the select menu didn't work in Firefox and MS Edge. So we are now using MutationObserver instead, which is recommended, and solves the problem.
